### PR TITLE
Add DNS Hostname support, explicit Gateway Endpoints, and VPC Flow Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You are free to use any /16 to /28 CIDR block in the RFC 1918 private address ra
 
 ## VPC Template Parameters
 
-To deploy this VPC template, you'll need to know the VPC CIDR block, the three public, and three private subnet CIDR blocks. You will also choose whether the VPC will support highly available NAT Gateways and VPC Flow Logs, or, by default, a more cost effective single NAT Gateway without VPC Flow Logs enabled.
+To deploy this VPC template, you'll need to know the VPC CIDR block, the three public, and three private subnet CIDR blocks. You will need to choose whether the VPC will support highly available NAT Gateways, or, by default, a more cost effective single NAT Gateway. You will also need to choose whether VPC Flow Logs will be enabled, or disabled (default behavior is disabled to reduce costs).
 
 | Parameter                 | Description                  | Example      |
 |---------------------------|------------------------------|--------------|

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You are free to use any /16 to /28 CIDR block in the RFC 1918 private address ra
 
 ## VPC Template Parameters
 
-To deploy this VPC template, you'll need to know the VPC CIDR block, the three public, and three private subnet CIDR blocks. You will also choose whether the VPC will support highly available NAT Gateways, or, by default, a more cost effective single NAT Gateway.
+To deploy this VPC template, you'll need to know the VPC CIDR block, the three public, and three private subnet CIDR blocks. You will also choose whether the VPC will support highly available NAT Gateways and VPC Flow Logs, or, by default, a more cost effective single NAT Gateway without VPC Flow Logs enabled.
 
 | Parameter                 | Description                  | Example      |
 |---------------------------|------------------------------|--------------|
@@ -49,9 +49,21 @@ To deploy this VPC template, you'll need to know the VPC CIDR block, the three p
 | _PrivateAZBSubnetBlock_   | AZ B private subnet block    | 10.0.64.0/19 |
 | _PrivateAZCSubnetBlock_   | AZ C private subnet block    | 10.0.128.0/19|
 | _HighlyAvailable_         | Highly Available NAT config  |     true     |
+| _EnableVpcFlowLogs_       | VPC Flow Logs                |     true     |
 
 
 To make it easier to specify these parameters on the command line, you can use the example Parameters files included in the `parameters/` directory.
+
+## VPC Flow Logs
+
+[VPC Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html) is a feature that allows you to capture information about IP traffic going to and from network interfaces in your VPC. This template is configured to deliver this data to a CloudWatch Logs Group called `FlowLogs/<CloudFormation Stack Name>`. Enabling VPC Flow Logs will increase your monthly usage costs (see [VPC Flow Logs Pricing](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-logs-pricing) and [CloudWatch Pricing](https://aws.amazon.com/cloudwatch/pricing/) pages).
+
+Per the AWS Docs, Flow logs can help you with a number of tasks, such as:
+- Diagnosing overly restrictive security group rules
+- Monitoring the traffic that is reaching your instance
+- Determining the direction of the traffic to and from the network interfaces
+
+VPC Flow Logs require an IAM role to give the VPC Flow Logs service permission to delivery flow logs to CloudWatch Logs. This IAM role only has permission to create and read CloudWatch log groups, log streams, and put log events.
 
 ## How to Deploy
 
@@ -75,6 +87,12 @@ Run this command in the AWS CLI:
 
 ```shell
 aws cloudformation deploy --template-file network.yaml --stack-name main-vpc --parameter-overrides file://parameters/us-west-2/dev.json
+```
+
+If you have the `EnableVpcFlowLogs` parameter set to `true`, you will need to add `--capabilities CAPABILITY_IAM` to the CLI command since enabling VPC Flow Logs requires creation of an IAM role to give the VPC Flow Logs service permission to write to CloudWatch Logs.
+
+```shell
+aws cloudformation deploy --template-file network.yaml --stack-name main-vpc --parameter-overrides file://parameters/us-west-2/dev.json --capabilities CAPABILITY_IAM
 ```
 
 ### Update Stack

--- a/network.yaml
+++ b/network.yaml
@@ -528,6 +528,8 @@ Resources:
   VpcFlowLogs:
     Type: AWS::EC2::FlowLog
     Condition: VpcFlowLogs
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       DeliverLogsPermissionArn: !GetAtt FlowLogsRole.Arn
       LogDestination: !GetAtt FlowLogLogGroup.Arn

--- a/network.yaml
+++ b/network.yaml
@@ -464,6 +464,7 @@ Resources:
           - !Ref "AWS::Region"
           - .s3
       VpcId: !Ref Vpc
+      VpcEndpointType: Gateway
 
   DynamoDBVPCEndpoint:
     Type: "AWS::EC2::VPCEndpoint"
@@ -479,3 +480,4 @@ Resources:
           - !Ref "AWS::Region"
           - .dynamodb
       VpcId: !Ref Vpc
+      VpcEndpointType: Gateway

--- a/network.yaml
+++ b/network.yaml
@@ -145,6 +145,8 @@ Resources:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: !Ref VpcCidrParam
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
       Tags:
         - Key: Name
           Value: !Sub ${AWS::StackName}

--- a/network.yaml
+++ b/network.yaml
@@ -70,9 +70,17 @@ Parameters:
     Default: "false"
     ConstraintDescription: must be true or false (case sensitive).
 
+  EnableVpcFlowLogs:
+    Type: String
+    Description: Optional configuration for enabling VPC Flow Logs sent to CloudWatch Logs. Default configuration has no VPC Flow Logs enabled.
+    AllowedPattern: "^(true|false)$"
+    Default: "false"
+    ConstraintDescription: must be true or false (case sensitive).
+
 Conditions:
   HighlyAvailable: !Equals [!Ref HighlyAvailableNat, "true"]
   NotHighlyAvailable: !Equals [!Ref HighlyAvailableNat, "false"]
+  VpcFlowLogs: !Equals [!Ref EnableVpcFlowLogs, "true"]
 Outputs:
   VpcId:
     Description: VPC Id
@@ -433,7 +441,7 @@ Resources:
     Properties:
       SubnetId: !Ref PrivateAZCSubnet
       RouteTableId: !Ref PrivateAZCRouteTable
-  
+
   NotHighlyAvailablePrivateAZCRoute:
     Type: AWS::EC2::Route
     Condition: NotHighlyAvailable
@@ -481,3 +489,49 @@ Resources:
           - .dynamodb
       VpcId: !Ref Vpc
       VpcEndpointType: Gateway
+
+  # VPC Flow Logs
+  FlowLogLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: VpcFlowLogs
+    Properties:
+      LogGroupName: !Sub "FlowLogs/${AWS::StackName}"
+      RetentionInDays: 7
+
+  FlowLogsRole:
+    Type: AWS::IAM::Role
+    Condition: VpcFlowLogs
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - vpc-flow-logs.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: AllowPublishingFlowLogsToCloudWatch
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogGroups
+                  - logs:DescribeLogStreams
+                Resource: "*"
+
+  VpcFlowLogs:
+    Type: AWS::EC2::FlowLog
+    Condition: VpcFlowLogs
+    Properties:
+      DeliverLogsPermissionArn: !GetAtt FlowLogsRole.Arn
+      LogDestination: !GetAtt FlowLogLogGroup.Arn
+      LogDestinationType: cloud-watch-logs
+      ResourceId: !Ref Vpc
+      ResourceType: VPC
+      TrafficType: ALL

--- a/parameters/us-east-1/dev.json
+++ b/parameters/us-east-1/dev.json
@@ -6,5 +6,6 @@
     "PublicAZBSubnetBlock=10.64.96.0/20",
     "PrivateAZCSubnetBlock=10.64.128.0/19",
     "PublicAZCSubnetBlock=10.64.160.0/20",
-    "HighlyAvailableNat=true"
+    "HighlyAvailableNat=true",
+    "EnableVpcFlowLogs=false"
 ]

--- a/parameters/us-west-2/dev.json
+++ b/parameters/us-west-2/dev.json
@@ -6,5 +6,6 @@
     "PublicAZBSubnetBlock=10.0.96.0/20",
     "PrivateAZCSubnetBlock=10.0.128.0/19",
     "PublicAZCSubnetBlock=10.0.160.0/20",
-    "HighlyAvailableNat=true"
+    "HighlyAvailableNat=true",
+    "EnableVpcFlowLogs=true"
 ]


### PR DESCRIPTION
- Enables DNS Hostname support on the VPC.
- Explicitly configures S3 and DynamoDB endpoints as Gateway Endpoints to avoid confusion.
- Adds option to enable VPC Flow Logs that are delivered to CloudWatch Logs.